### PR TITLE
perf: 非表示タブの遅延ロード化

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useState, lazy, Suspense } from 'react';
 import { PdfToImageConverter } from './components/PdfToImageConverter';
-import { ImageToPdfConverter } from './components/ImageToPdfConverter';
-import { PdfMerger } from './components/PdfMerger';
 import { FileText, Image, Github, Combine } from 'lucide-react';
+
+const ImageToPdfConverter = lazy(() => import('./components/ImageToPdfConverter'));
+const PdfMerger = lazy(() => import('./components/PdfMerger'));
 
 type Tab = 'pdf-to-image' | 'image-to-pdf' | 'pdf-merge';
 
@@ -74,13 +75,15 @@ function App() {
           </div>
 
           <div className="p-6">
-            {activeTab === 'pdf-to-image' ? (
-              <PdfToImageConverter />
-            ) : activeTab === 'image-to-pdf' ? (
-              <ImageToPdfConverter />
-            ) : (
-              <PdfMerger />
-            )}
+            <Suspense fallback={<div className="flex items-center justify-center h-64 text-gray-500">読み込み中...</div>}>
+              {activeTab === 'pdf-to-image' ? (
+                <PdfToImageConverter />
+              ) : activeTab === 'image-to-pdf' ? (
+                <ImageToPdfConverter />
+              ) : (
+                <PdfMerger />
+              )}
+            </Suspense>
           </div>
         </div>
 

--- a/src/components/ImageToPdfConverter.tsx
+++ b/src/components/ImageToPdfConverter.tsx
@@ -5,7 +5,7 @@ import { imagesToPdf, loadImage } from '../utils/imagesToPdf';
 import type { ImageFile } from '../utils/imagesToPdf';
 import { Image, Download, Trash2, GripVertical, ChevronUp, ChevronDown, FileImage, ArrowDownUp } from 'lucide-react';
 
-export function ImageToPdfConverter() {
+export default function ImageToPdfConverter() {
   const [images, setImages] = useState<ImageFile[]>([]);
   const [isConverting, setIsConverting] = useState(false);
   const [progress, setProgress] = useState(0);

--- a/src/components/PdfMerger.tsx
+++ b/src/components/PdfMerger.tsx
@@ -25,7 +25,7 @@ interface PdfFile {
   bytes: ArrayBuffer;
 }
 
-export function PdfMerger() {
+export default function PdfMerger() {
   const [pdfFiles, setPdfFiles] = useState<PdfFile[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isMerging, setIsMerging] = useState(false);


### PR DESCRIPTION
## Summary
- `ImageToPdfConverter` と `PdfMerger` を `React.lazy` + `Suspense` による遅延ロードに変更
- 初期表示タブ (`PdfToImageConverter`) 以外の依存が初期バンドルに含まれないように分割

## Build result
| | Before | After |
|---|---|---|
| メインチャンク | 1,595KB (gzip 538KB) | **1,157KB (gzip 400KB)** |
| ImageToPdfConverter | - | 391KB (別チャンク) |
| PdfMerger | - | 8KB (別チャンク) |

## Test plan
- [ ] 初期表示(PDF→画像タブ)が正常に動作すること
- [ ] 画像→PDFタブに切り替えた際、遅延ロード後に正常に動作すること
- [ ] PDF結合タブに切り替えた際、遅延ロード後に正常に動作すること
- [ ] ビルドでメインチャンクが分割されていること

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)